### PR TITLE
Add Seedream AI Studio to image generation collection

### DIFF
--- a/src/app/[locale]/(docs)/awesome-ai-products/data.ts
+++ b/src/app/[locale]/(docs)/awesome-ai-products/data.ts
@@ -156,6 +156,7 @@ export const data: dataType = [
       { id: 'code-former', name: 'Code Former', url: 'https://huggingface.co/spaces/sczhou/CodeFormer', iconType: 'svg' },
       { id: 'lexica', name: 'Lexica', url: 'https://lexica.art/', iconType: 'png' },
       { id: 'leonardo', name: 'Leonardo', url: 'https://leonardo.ai/', iconType: 'svg' },
+      { id: 'seedream-ai-studio', name: 'Seedream AI Studio', url: 'https://seedream4.video/' },
     ],
   },
   {


### PR DESCRIPTION
## Description

Adding [Seedream AI Studio](https://seedream4.video/) to the **Image** category in the awesome-ai-products collection.

Seedream AI Studio is a multi-model AI image generation platform by ByteDance, featuring:
- **Seedream 5.0/4.5/4.0** model support for high-quality image generation
- **One-click image-to-video** animation powered by Kling 2.1
- Free tier available for users to try

## Change

Added to `src/app/[locale]/(docs)/awesome-ai-products/data.ts` in the `image` category:

```ts
{ id: 'seedream-ai-studio', name: 'Seedream AI Studio', url: 'https://seedream4.video/' }
```

This fits perfectly alongside existing entries like DALL-E, Midjourney, DreamStudio, and Leonardo.